### PR TITLE
`else` and `else if (...)`'s start with a carriage return

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,14 @@ let myClass = MyModule.UsefulClass()
 
 * Method braces and other braces (`if`/`else`/`switch`/`while` etc.) always open on the same line as the statement but close on a new line.
 * Tip: You can re-indent by selecting some code (or ⌘A to select all) and then Control-I (or Editor\Structure\Re-Indent in the menu). Some of the Xcode template code will have 4-space tabs hard coded, so this is a good way to fix that.
+* `else` and `else if (...)`'s start with a carriage return.
 
 **Preferred:**
 ```swift
 if user.isHappy {
   // Do something
-} else {
+}
+else {
   // Do something else
 }
 ```
@@ -164,8 +166,7 @@ if user.isHappy {
 if user.isHappy
 {
     // Do something
-}
-else {
+} else {
     // Do something else
 }
 ```


### PR DESCRIPTION
I did miss it in #1. It should match with our obj-c code style unless we decide to use different style.
